### PR TITLE
Don't frame missing data

### DIFF
--- a/client/python/lkapi.py
+++ b/client/python/lkapi.py
@@ -58,7 +58,6 @@ def lk_api_data_to_frames(data:typing.List[typing.Dict[str, typing.Any]]) -> typ
         data: A json like dictionary
     Returns: A dictionary of frames or None if the request fails.
     """
-
     # we are assuming layout json but if we could have different types in addition to different versions switch here
     data_type = 'layout'
     if data_type == 'layout':
@@ -87,7 +86,6 @@ def lk_layout_element_to_frames(data: typing.Dict[str, typing.Any]) -> typing.Op
     Returns: A dictionary of pandas frames.
     """
     frame_data = {}
-
     data_version = data['version']
 
     if data_version == 1:
@@ -205,7 +203,11 @@ def lk_layout_data_to_frame_v2(data: typing.Dict[str, typing.Any], data_type, da
     # data_type = data['type']
     # data_depth = data['depth']
     # data_headers = data['headers']
-    is_grouped = "groups" in data.keys()
+    is_grouped = "groups" in data
+    has_data = "data" in data
+    if not is_grouped and not has_data:
+        # Stub block (e.g. time when viewby=rollup): only metadata present, no data to frame.
+        return None
 
     if data_type == 'Net' and data_headers[0] == 'Total':
         # drop the total since it isn't helpful


### PR DESCRIPTION
When an API view is queried with viewby=rollup, the response's time block is a metadata-only stub ({'name': '...', 'totals': [...]}) rather than a full data payload. The parser was unconditionally accessing data['data'] on every block, which raised a KeyError for these stubs.

Changes:

In lk_layout_data_to_frame_v2, detect stub blocks — those with neither a data key nor a groups key — and return None early. The existing null-check in lk_layout_element_to_frames already gates frame insertion, so the time key is simply omitted from the result when it contains no data.
Result:

viewby=rollup → result dict contains only rollup frame
viewby=time or no viewby → result dict contains both rollup and time frames (unchanged)
