### PR TITLE
fix: publish to PyPI from the correct release-please outputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,16 +3,27 @@ name: release
 on:
   push:
     branches: [main]
+  # Manual re-publish of an existing tag to PyPI (e.g. if the automated
+  # publish was skipped). Runs the publish-pypi job against the given tag.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing git tag to build and publish to PyPI (e.g. 0.3.0)"
+        required: true
+        type: string
 
 jobs:
   release-please:
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
+      # The package is configured under the "python" path, so release-please
+      # emits path-prefixed outputs (python--*) rather than the bare names.
+      release_created: ${{ steps.release.outputs['python--release_created'] }}
+      tag_name: ${{ steps.release.outputs['python--tag_name'] }}
     steps:
       - id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
@@ -25,7 +36,13 @@ jobs:
   # releases created with GITHUB_TOKEN do not trigger other workflows.
   publish-pypi:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
+    # Run when release-please created a release (push), or on a manual
+    # dispatch. !cancelled() lets this run even though release-please is
+    # skipped on workflow_dispatch.
+    if: >-
+      ${{ !cancelled() && !failure() &&
+          (github.event_name == 'workflow_dispatch' ||
+           needs.release-please.outputs.release_created == 'true') }}
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -34,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || needs.release-please.outputs.tag_name }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5


### PR DESCRIPTION
## Problem

`publish-pypi` was skipped on every release, so `0.3.0` was tagged and GitHub-released but never reached PyPI (PyPI still shows `0.2.0`).

Root cause: the package is configured under the `python/` path in `release-please-config.json`, so release-please emits **path-prefixed** outputs (`python--release_created`, `python--tag_name`). The workflow read the bare `release_created` / `tag_name`, which are always empty in this mode, so the publish job's `if:` gate was false. (The runnerctl template this was based on uses a root `.` package, where the bare outputs are populated.)

## Fix

- Read the prefixed outputs (`python--release_created`, `python--tag_name`) so the publish job fires on release.
- Add a `workflow_dispatch` trigger to manually build and publish an existing tag. This keeps the `pypi` environment approval gate and lets us backfill `0.3.0`.

## After merge

Run the workflow manually against tag `0.3.0` to publish it (will pause for pypi environment approval):

```
gh workflow run release.yml -f tag=0.3.0
```

Future releases publish automatically when a release PR merges.